### PR TITLE
Generalize validateMap to support multiple errors

### DIFF
--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -1088,7 +1088,7 @@ map mapFn field_ =
               Username string |> Ok
 
 -}
-validateMap : (parsed -> Result error mapped) -> Field error parsed input initial kind constraints -> Field error mapped input initial kind { constraints | wasMapped : Yes }
+validateMap : (parsed -> Result (List error) mapped) -> Field error parsed input initial kind constraints -> Field error mapped input initial kind { constraints | wasMapped : Yes }
 validateMap mapFn (Internal.Field.Field field kind) =
     validateMap_
         (\parsed ->
@@ -1096,8 +1096,8 @@ validateMap mapFn (Internal.Field.Field field kind) =
                 Ok mapped ->
                     ( Just mapped, [] )
 
-                Err error ->
-                    ( Nothing, [ error ] )
+                Err errors ->
+                    ( Nothing, errors )
         )
         (Internal.Field.Field field kind)
 


### PR DESCRIPTION
Hello,

I am currently experimenting with your library and I would like to propose a new feature. I believe it would be beneficial to have a mechanism for validating/parsing a password based on a specified policy. Passwords can be complex and varied, so I think it would be valuable to display multiple errors indicating where the password fails to meet the policy requirements. However, I couldn't find a straightforward way to achieve this in the current implementation.

If there is already a solution for this functionality, please disregard this pull request. I would greatly appreciate your guidance on how I can proceed with implementing this feature if it is already possible.

Cheers and thank you for developing this library