### PR TITLE
Fix references to Field.number in docs for int and float

### DIFF
--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -720,7 +720,7 @@ Floating point numbers will give a validation error, using the error value passe
     import Form.Field as Field
 
     example =
-        Field.number
+        Field.int
             { invalid =
                 \value -> "Must be an integer"
             }
@@ -782,7 +782,7 @@ It will give a validation error if the input is not a number, using the error va
     import Form.Field as Field
 
     example =
-        Field.number
+        Field.float
             { invalid =
                 \value -> "Must be a number"
             }


### PR DESCRIPTION
Hi! The docs for `Field.int` and `Field.float` both have an example in their docs that uses `Field.number` instead. Probably a remnant of an older API? This PR fixes these doc comments.

Have a great day!