### PR TITLE
Add formatOnEvent for transforming field values on events

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,8 @@
         "Form.Validation",
         "Form",
         "Form.FieldView",
-        "Form.Handler"
+        "Form.Handler",
+        "Form.Field.Selection"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/examples/src/DynamicFormatOnEvent.elm
+++ b/examples/src/DynamicFormatOnEvent.elm
@@ -1,0 +1,277 @@
+module DynamicFormatOnEvent exposing (Model, Msg, init, update, view)
+
+import Form
+import Form.Field as Field
+import Form.Field.Selection as Selection
+import Form.FieldView as FieldView
+import Form.Validation as Validation
+import Html exposing (Html)
+import Html.Attributes as Attr
+
+
+type Msg
+    = FormMsg (Form.Msg Msg)
+    | OnSubmit
+        { fields : List ( String, String )
+        , method : Form.Method
+        , action : String
+        , parsed : Form.Validated String ContactInfo
+        }
+
+
+type alias Model =
+    { formState : Form.Model
+    , submitting : Bool
+    , lastSubmission : Maybe (Form.Validated String ContactInfo)
+    }
+
+
+init : Model
+init =
+    { formState = Form.init
+    , submitting = False
+    , lastSubmission = Nothing
+    }
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        OnSubmit { parsed } ->
+            let
+                _ =
+                    Debug.log "Submitted" parsed
+            in
+            ( { model | lastSubmission = Just parsed }, Cmd.none )
+
+        FormMsg formMsg ->
+            let
+                ( updatedFormModel, cmd ) =
+                    Form.update formMsg model.formState
+            in
+            ( { model | formState = updatedFormModel }, cmd )
+
+
+view : Model -> Html Msg
+view model =
+    Html.div [ Attr.style "max-width" "600px", Attr.style "margin" "2rem auto", Attr.style "font-family" "sans-serif" ]
+        [ Html.h2 [] [ Html.text "Dynamic Form with formatOnEvent" ]
+        , Html.p [ Attr.style "color" "#666" ]
+            [ Html.text "Select a contact type, then fill in the fields. The phone field formats on blur (adds dashes). The email field lowercases on blur." ]
+        , contactForm
+            |> Form.renderHtml
+                { submitting = model.submitting
+                , state = model.formState
+                , toMsg = FormMsg
+                }
+                (Form.options "dynamic-format"
+                    |> Form.withOnSubmit OnSubmit
+                )
+                [ Attr.style "display" "flex", Attr.style "flex-direction" "column", Attr.style "gap" "1rem" ]
+        , case model.lastSubmission of
+            Just (Form.Valid value) ->
+                Html.div [ Attr.style "margin-top" "1rem", Attr.style "padding" "1rem", Attr.style "background" "#e8f5e9" ]
+                    [ Html.text ("Submitted: " ++ contactInfoToString value) ]
+
+            Just (Form.Invalid _ errors) ->
+                Html.div [ Attr.style "margin-top" "1rem", Attr.style "padding" "1rem", Attr.style "background" "#fce4ec" ]
+                    [ Html.text ("Invalid: " ++ Debug.toString errors) ]
+
+            Nothing ->
+                Html.text ""
+        ]
+
+
+
+-- TYPES
+
+
+type ContactType
+    = Phone
+    | Email
+
+
+type ContactInfo
+    = PhoneContact { phone : String }
+    | EmailContact { email : String }
+
+
+contactInfoToString : ContactInfo -> String
+contactInfoToString info =
+    case info of
+        PhoneContact { phone } ->
+            "Phone: " ++ phone
+
+        EmailContact { email } ->
+            "Email: " ++ email
+
+
+
+-- FORMS
+
+
+contactForm : Form.HtmlForm String ContactInfo () Msg
+contactForm =
+    (\contactType subForm ->
+        { combine =
+            contactType
+                |> Validation.andThen subForm.combine
+        , view =
+            \formState ->
+                [ Html.div []
+                    [ Html.label []
+                        [ Html.text "Contact Type "
+                        , FieldView.select [] (\entry -> ( [], contactTypeToString entry )) contactType
+                        ]
+                    ]
+                , case Validation.value contactType of
+                    Just ct ->
+                        Html.div [] (subForm.view ct formState)
+
+                    Nothing ->
+                        Html.text "Select a contact type above"
+                , Html.button [ Attr.style "padding" "0.5rem 1rem" ] [ Html.text "Submit" ]
+                ]
+        }
+    )
+        |> Form.form
+        |> Form.field "contactType"
+            (Field.select
+                [ ( "phone", Phone )
+                , ( "email", Email )
+                ]
+                (\_ -> "Invalid contact type")
+                |> Field.required "Please select a contact type"
+            )
+        |> Form.dynamic
+            (\parsedType ->
+                case parsedType of
+                    Phone ->
+                        phoneSubForm
+
+                    Email ->
+                        emailSubForm
+            )
+
+
+phoneSubForm : Form.HtmlForm String ContactInfo () Msg
+phoneSubForm =
+    (\phone ->
+        { combine =
+            phone
+                |> Validation.map (\phoneValue -> PhoneContact { phone = phoneValue })
+        , view =
+            \formState ->
+                [ inputFieldView formState "Phone (formats on blur: 1234567890 → 123-456-7890)" phone
+                ]
+        }
+    )
+        |> Form.form
+        |> Form.field "phone"
+            (Field.text
+                |> Field.required "Phone is required"
+                |> Field.telephone
+                |> Field.formatOnEvent
+                    (\event ->
+                        case event of
+                            Field.Blur value ->
+                                let
+                                    digits =
+                                        String.filter Char.isDigit value
+                                in
+                                if String.length digits == 10 then
+                                    Just
+                                        (String.slice 0 3 digits
+                                            ++ "-"
+                                            ++ String.slice 3 6 digits
+                                            ++ "-"
+                                            ++ String.slice 6 10 digits
+                                        )
+
+                                else
+                                    Nothing
+
+                            Field.Input selection ->
+                                let
+                                    currentValue =
+                                        Selection.value selection
+
+                                    digitsOnly =
+                                        String.filter Char.isDigit currentValue
+                                in
+                                if digitsOnly /= currentValue then
+                                    Just digitsOnly
+
+                                else
+                                    Nothing
+
+                            Field.Focus _ ->
+                                Nothing
+                    )
+            )
+
+
+emailSubForm : Form.HtmlForm String ContactInfo () Msg
+emailSubForm =
+    (\email ->
+        { combine =
+            email
+                |> Validation.map (\emailValue -> EmailContact { email = emailValue })
+        , view =
+            \formState ->
+                [ inputFieldView formState "Email (lowercases on blur)" email
+                ]
+        }
+    )
+        |> Form.form
+        |> Form.field "email"
+            (Field.text
+                |> Field.required "Email is required"
+                |> Field.email
+                |> Field.formatOnEvent
+                    (\event ->
+                        case event of
+                            Field.Blur value ->
+                                Just (String.toLower value)
+
+                            _ ->
+                                Nothing
+                    )
+            )
+
+
+
+-- HELPERS
+
+
+contactTypeToString : ContactType -> String
+contactTypeToString ct =
+    case ct of
+        Phone ->
+            "Phone"
+
+        Email ->
+            "Email"
+
+
+inputFieldView : Form.Context String input -> String -> Validation.Field String parsed FieldView.Input -> Html msg
+inputFieldView formState label field =
+    Html.div []
+        [ Html.label []
+            [ Html.text (label ++ " ")
+            , FieldView.input [ Attr.style "padding" "0.25rem" ] field
+            ]
+        , errorsView formState field
+        ]
+
+
+errorsView : Form.Context String input -> Validation.Field String parsed kind -> Html msg
+errorsView { submitAttempted, errors } field =
+    if submitAttempted || Validation.statusAtLeast Validation.Blurred field then
+        errors
+            |> Form.errorsForField field
+            |> List.map (\error -> Html.li [ Attr.style "color" "red" ] [ Html.text error ])
+            |> Html.ul []
+
+    else
+        Html.ul [] []

--- a/examples/src/FormatOnBlurExample.elm
+++ b/examples/src/FormatOnBlurExample.elm
@@ -1,0 +1,270 @@
+module FormatOnBlurExample exposing (main)
+
+import Browser
+import Form
+import Form.Field as Field exposing (EventInfo(..))
+import Form.Field.Selection as Selection
+import Form.FieldView as FieldView
+import Form.Validation as Validation
+import Html exposing (Html)
+import Html.Attributes as Attr
+
+
+type Msg
+    = FormMsg (Form.Msg Msg)
+    | OnSubmit (Form.Validated String ContactForm)
+
+
+type alias Model =
+    { formState : Form.Model
+    , submitting : Bool
+    }
+
+
+type alias ContactForm =
+    { name : String
+    , email : String
+    , phone : String
+    , code : String
+    }
+
+
+main : Program () Model Msg
+main =
+    Browser.document
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = \_ -> Sub.none
+        }
+
+
+init : () -> ( Model, Cmd Msg )
+init _ =
+    ( { formState = Form.init
+      , submitting = False
+      }
+    , Cmd.none
+    )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        OnSubmit validated ->
+            case validated of
+                Form.Valid data ->
+                    let
+                        _ =
+                            Debug.log "Valid form data" data
+                    in
+                    ( { model | submitting = False }, Cmd.none )
+
+                Form.Invalid _ errors ->
+                    let
+                        _ =
+                            Debug.log "Form errors" errors
+                    in
+                    ( model, Cmd.none )
+
+        FormMsg formMsg ->
+            let
+                ( updatedFormModel, cmd ) =
+                    Form.update formMsg model.formState
+            in
+            ( { model | formState = updatedFormModel }, cmd )
+
+
+view : Model -> Browser.Document Msg
+view model =
+    { title = "formatOnEvent Example"
+    , body =
+        [ Html.div [ Attr.style "max-width" "600px", Attr.style "margin" "40px auto", Attr.style "font-family" "sans-serif" ]
+            [ Html.h1 [] [ Html.text "formatOnEvent Example" ]
+            , Html.p []
+                [ Html.text "This example demonstrates the "
+                , Html.code [] [ Html.text "formatOnEvent" ]
+                , Html.text " feature with different event types:"
+                ]
+            , Html.ul []
+                [ Html.li [] [ Html.text "Name, Email, Phone: formatted on blur only" ]
+                , Html.li [] [ Html.text "Code: formatted on input (when cursor at end) and blur" ]
+                ]
+            , Html.p []
+                [ Html.text "Try typing in the Code field - it will uppercase as you type, but only if your cursor is at the end. Try moving the cursor to the middle and typing to see the difference!" ]
+            , contactForm
+                |> Form.renderHtml
+                    { submitting = model.submitting
+                    , state = model.formState
+                    , toMsg = FormMsg
+                    }
+                    (Form.options "contact-form"
+                        |> Form.withOnSubmit (\{ parsed } -> OnSubmit parsed)
+                    )
+                    []
+            ]
+        ]
+    }
+
+
+contactForm : Form.HtmlForm String ContactForm input msg
+contactForm =
+    (\name email phone code ->
+        { combine =
+            Validation.succeed ContactForm
+                |> Validation.andMap name
+                |> Validation.andMap email
+                |> Validation.andMap phone
+                |> Validation.andMap code
+        , view =
+            \formState ->
+                [ fieldView formState "Name (trimmed on blur)" name
+                , fieldView formState "Email (trimmed and lowercased on blur)" email
+                , fieldView formState "Phone (formatted on blur)" phone
+                , fieldView formState "Code (uppercased as you type, only at end)" code
+                , Html.button
+                    [ Attr.style "margin-top" "20px"
+                    , Attr.style "padding" "10px 20px"
+                    ]
+                    [ if formState.submitting then
+                        Html.text "Submitting..."
+
+                      else
+                        Html.text "Submit"
+                    ]
+                ]
+        }
+    )
+        |> Form.form
+        |> Form.field "name"
+            (Field.text
+                |> Field.formatOnEvent
+                    (\event ->
+                        case event of
+                            Blur value ->
+                                Just (String.trim value)
+
+                            _ ->
+                                Nothing
+                    )
+                |> Field.required "Name is required"
+            )
+        |> Form.field "email"
+            (Field.text
+                |> Field.formatOnEvent
+                    (\event ->
+                        case event of
+                            Blur value ->
+                                Just (String.trim value |> String.toLower)
+
+                            _ ->
+                                Nothing
+                    )
+                |> Field.required "Email is required"
+                |> Field.email
+            )
+        |> Form.field "phone"
+            (Field.text
+                |> Field.formatOnEvent
+                    (\event ->
+                        case event of
+                            Blur value ->
+                                Just (formatPhoneNumber value)
+
+                            _ ->
+                                Nothing
+                    )
+                |> Field.required "Phone is required"
+            )
+        |> Form.field "code"
+            (Field.text
+                |> Field.formatOnEvent
+                    (\event ->
+                        case event of
+                            Input selection ->
+                                -- Only format if cursor is at the end
+                                if Selection.cursorAtEnd selection then
+                                    Just (Selection.value selection |> String.toUpper)
+
+                                else
+                                    Nothing
+
+                            Blur value ->
+                                -- Always format on blur
+                                Just (String.toUpper value)
+
+                            _ ->
+                                Nothing
+                    )
+                |> Field.required "Code is required"
+            )
+
+
+fieldView :
+    Form.Context String input
+    -> String
+    -> Validation.Field String parsed FieldView.Input
+    -> Html msg
+fieldView formState label field =
+    Html.div [ Attr.style "margin-bottom" "20px" ]
+        [ Html.label [ Attr.style "display" "block", Attr.style "margin-bottom" "5px", Attr.style "font-weight" "bold" ]
+            [ Html.text label ]
+        , FieldView.input
+            [ Attr.style "width" "100%"
+            , Attr.style "padding" "8px"
+            , Attr.style "font-size" "16px"
+            , Attr.style "border" "1px solid #ccc"
+            , Attr.style "border-radius" "4px"
+            ]
+            field
+        , errorsView formState field
+        ]
+
+
+errorsView :
+    Form.Context String input
+    -> Validation.Field String parsed FieldView.Input
+    -> Html msg
+errorsView formState field =
+    if formState.submitAttempted || Validation.statusAtLeast Validation.Blurred field then
+        formState.errors
+            |> Form.errorsForField field
+            |> List.map
+                (\error ->
+                    Html.div
+                        [ Attr.style "color" "red"
+                        , Attr.style "margin-top" "5px"
+                        , Attr.style "font-size" "14px"
+                        ]
+                        [ Html.text error ]
+                )
+            |> Html.div []
+
+    else
+        Html.text ""
+
+
+{-| Simple phone number formatter: removes non-digits and formats as (XXX) XXX-XXXX
+-}
+formatPhoneNumber : String -> String
+formatPhoneNumber input =
+    let
+        digits =
+            input
+                |> String.filter Char.isDigit
+                |> String.left 10
+    in
+    case String.length digits of
+        10 ->
+            "("
+                ++ String.left 3 digits
+                ++ ") "
+                ++ String.slice 3 6 digits
+                ++ "-"
+                ++ String.dropLeft 6 digits
+
+        7 ->
+            String.left 3 digits ++ "-" ++ String.dropLeft 3 digits
+
+        _ ->
+            digits

--- a/examples/src/Main.elm
+++ b/examples/src/Main.elm
@@ -1,6 +1,7 @@
 module Main exposing (main)
 
 import Browser
+import DynamicFormatOnEvent
 import Form
 import Form.Field as Field
 import Form.FieldView as FieldView
@@ -18,6 +19,7 @@ type Msg
         , action : String
         , parsed : Form.Validated String SignUpForm
         }
+    | DynamicMsg DynamicFormatOnEvent.Msg
 
 
 type alias Flags =
@@ -37,6 +39,7 @@ main =
 type alias Model =
     { formState : Form.Model
     , submitting : Bool
+    , dynamicModel : DynamicFormatOnEvent.Model
     }
 
 
@@ -44,6 +47,7 @@ init : Flags -> ( Model, Cmd Msg )
 init flags =
     ( { formState = Form.init
       , submitting = False
+      , dynamicModel = DynamicFormatOnEvent.init
       }
     , Cmd.none
     )
@@ -66,6 +70,13 @@ update msg model =
             in
             ( { model | formState = updatedFormModel }, cmd )
 
+        DynamicMsg dynamicMsg ->
+            let
+                ( updatedDynamic, cmd ) =
+                    DynamicFormatOnEvent.update dynamicMsg model.dynamicModel
+            in
+            ( { model | dynamicModel = updatedDynamic }, Cmd.map DynamicMsg cmd )
+
 
 view : Model -> Browser.Document Msg
 view model =
@@ -83,6 +94,9 @@ view model =
                     )
                     []
             ]
+        , Html.hr [] []
+        , DynamicFormatOnEvent.view model.dynamicModel
+            |> Html.map DynamicMsg
         ]
     }
 

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -463,7 +463,6 @@ dynamic :
     ->
         Form
             error
-            --((decider -> Validation error parsed named) -> combined)
             ({ combine : decider -> Validation error parsed named constraints1
              , view : decider -> subView
              }
@@ -522,7 +521,7 @@ dynamic forms (Internal.Form.Form _ parseFn _) =
                                         |> toParser
                                         |> .combineAndView
                                         |> .combine
-                                        |> (\(Validation a b ( maybeParsed, errors )) ->
+                                        |> (\(Validation a b ( maybeParsed, errors ) handlers) ->
                                                 Validation a
                                                     b
                                                     ( maybeParsed
@@ -540,6 +539,7 @@ dynamic forms (Internal.Form.Form _ parseFn _) =
                                                         (toResult2 decider)
                                                         Dict.empty
                                                     )
+                                                    handlers
                                            )
                             , view =
                                 \decider ->
@@ -658,10 +658,6 @@ field name (Internal.Field.Field fieldParser kind) (Internal.Form.Form definitio
         )
         (\maybeData formState ->
             let
-                ( maybeParsed, errors ) =
-                    -- @@@@@@ use code from here
-                    fieldParser.decode rawFieldValue
-
                 ( rawFieldValue, fieldStatus ) =
                     case formState.fields |> Dict.get name of
                         Just info ->
@@ -670,6 +666,9 @@ field name (Internal.Field.Field fieldParser kind) (Internal.Form.Form definitio
                         Nothing ->
                             ( maybeData |> Maybe.andThen (\data -> fieldParser.initialValue data), Form.FieldStatus.notVisited )
 
+                ( maybeParsed, errors ) =
+                    fieldParser.decode rawFieldValue
+
                 thing : Pages.Internal.Form.ViewField kind
                 thing =
                     { value = rawFieldValue
@@ -677,9 +676,18 @@ field name (Internal.Field.Field fieldParser kind) (Internal.Form.Form definitio
                     , kind = ( kind, fieldParser.properties )
                     }
 
+                eventHandlerDict : Dict String Pages.Internal.Form.EventHandler
+                eventHandlerDict =
+                    case fieldParser.formatOnEvent of
+                        Just handler ->
+                            Dict.singleton name handler
+
+                        Nothing ->
+                            Dict.empty
+
                 parsedField : Form.Validation.Field error parsed kind
                 parsedField =
-                    Pages.Internal.Form.Validation (Just thing) (Just name) ( maybeParsed, Dict.empty )
+                    Pages.Internal.Form.Validation (Just thing) (Just name) ( maybeParsed, Dict.empty ) eventHandlerDict
 
                 myFn :
                     { result : Dict String (List error)
@@ -692,16 +700,11 @@ field name (Internal.Field.Field fieldParser kind) (Internal.Form.Form definitio
                         , isMatchCandidate : Bool
                         }
                 myFn soFar =
-                    let
-                        validationField : Form.Validation.Field error parsed kind
-                        validationField =
-                            parsedField
-                    in
                     { result =
                         soFar.result
                             |> addErrorsInternal name errors
                     , combineAndView =
-                        soFar.combineAndView validationField
+                        soFar.combineAndView parsedField
                     , isMatchCandidate = soFar.isMatchCandidate
                     }
             in
@@ -756,9 +759,6 @@ hiddenField name (Internal.Field.Field fieldParser _) (Internal.Form.Form defini
         )
         (\maybeData formState ->
             let
-                ( maybeParsed, errors ) =
-                    fieldParser.decode rawFieldValue
-
                 ( rawFieldValue, fieldStatus ) =
                     case formState.fields |> Dict.get name of
                         Just info ->
@@ -767,6 +767,9 @@ hiddenField name (Internal.Field.Field fieldParser _) (Internal.Form.Form defini
                         Nothing ->
                             ( maybeData |> Maybe.andThen (\data -> fieldParser.initialValue data), Form.FieldStatus.notVisited )
 
+                ( maybeParsed, errors ) =
+                    fieldParser.decode rawFieldValue
+
                 thing : Pages.Internal.Form.ViewField Form.FieldView.Hidden
                 thing =
                     { value = rawFieldValue
@@ -774,9 +777,18 @@ hiddenField name (Internal.Field.Field fieldParser _) (Internal.Form.Form defini
                     , kind = ( Internal.Input.Hidden, fieldParser.properties )
                     }
 
+                eventHandlerDict : Dict String Pages.Internal.Form.EventHandler
+                eventHandlerDict =
+                    case fieldParser.formatOnEvent of
+                        Just handler ->
+                            Dict.singleton name handler
+
+                        Nothing ->
+                            Dict.empty
+
                 parsedField : Form.Validation.Field error parsed Form.FieldView.Hidden
                 parsedField =
-                    Pages.Internal.Form.Validation (Just thing) (Just name) ( maybeParsed, Dict.empty )
+                    Pages.Internal.Form.Validation (Just thing) (Just name) ( maybeParsed, Dict.empty ) eventHandlerDict
 
                 myFn :
                     { result : Dict String (List error)
@@ -789,16 +801,11 @@ hiddenField name (Internal.Field.Field fieldParser _) (Internal.Form.Form defini
                         , isMatchCandidate : Bool
                         }
                 myFn soFar =
-                    let
-                        validationField : Form.Validation.Field error parsed Form.FieldView.Hidden
-                        validationField =
-                            parsedField
-                    in
                     { result =
                         soFar.result
                             |> addErrorsInternal name errors
                     , combineAndView =
-                        soFar.combineAndView validationField
+                        soFar.combineAndView parsedField
                     , isMatchCandidate = soFar.isMatchCandidate
                     }
             in
@@ -944,7 +951,7 @@ mergeResults :
     -> Validation error parsed unnamed constraints2
 mergeResults parsed =
     let
-        ( Pages.Internal.Form.Validation _ name ( parsedThing, combineErrors ), individualFieldErrors ) =
+        ( Pages.Internal.Form.Validation _ name ( parsedThing, combineErrors ) handlers, individualFieldErrors ) =
             parsed.result
     in
     Pages.Internal.Form.Validation Nothing
@@ -952,6 +959,7 @@ mergeResults parsed =
         ( parsedThing
         , mergeErrors combineErrors individualFieldErrors
         )
+        handlers
 
 
 mergeErrors : Dict comparable (List value) -> Dict comparable (List value) -> Dict comparable (List value)
@@ -1041,7 +1049,7 @@ insertIfNonempty key values dict =
 
 
 unwrapValidation : Validation error parsed named constraints -> ( Maybe parsed, Dict String (List error) )
-unwrapValidation (Pages.Internal.Form.Validation _ _ ( maybeParsed, errors )) =
+unwrapValidation (Pages.Internal.Form.Validation _ _ ( maybeParsed, errors ) _) =
     ( maybeParsed, errors )
 
 
@@ -1148,11 +1156,11 @@ renderHelper :
             parsed
             input
     -> Html mappedMsg
-renderHelper formState options_ attrs ((Internal.Form.Form _ _ _) as form_) =
+renderHelper formState options_ attrs form_ =
     -- TODO Get transition context from `app` so you can check if the current form is being submitted
     -- TODO either as a transition or a fetcher? Should be easy enough to check for the `id` on either of those?
     let
-        { hiddenInputs, children, parsed, fields, errors } =
+        { hiddenInputs, children, parsed, fields, errors, eventHandlers } =
             helperValues options_ toHiddenInput formState form_
 
         toHiddenInput : List (Html.Attribute mappedMsg) -> Html mappedMsg
@@ -1160,7 +1168,7 @@ renderHelper formState options_ attrs ((Internal.Form.Form _ _ _) as form_) =
             Html.input hiddenAttrs []
     in
     Html.form
-        ((Form.listeners options_.id
+        ((Form.listeners options_.id eventHandlers
             |> List.map (Attr.map (Internal.FieldEvent.FormFieldEvent >> formState.toMsg))
          )
             ++ [ Attr.method (methodToString options_.method)
@@ -1225,11 +1233,11 @@ renderStyledHelper :
             parsed
             input
     -> Html.Styled.Html mappedMsg
-renderStyledHelper formState options_ attrs ((Internal.Form.Form _ _ _) as form_) =
+renderStyledHelper formState options_ attrs form_ =
     -- TODO Get transition context from `app` so you can check if the current form is being submitted
     -- TODO either as a transition or a fetcher? Should be easy enough to check for the `id` on either of those?
     let
-        { hiddenInputs, children, parsed, fields, errors } =
+        { hiddenInputs, children, parsed, fields, errors, eventHandlers } =
             helperValues options_ toHiddenInput formState form_
 
         toHiddenInput : List (Html.Attribute msg) -> Html.Styled.Html msg
@@ -1237,7 +1245,7 @@ renderStyledHelper formState options_ attrs ((Internal.Form.Form _ _ _) as form_
             Html.Styled.input (hiddenAttrs |> List.map StyledAttr.fromUnstyled) []
     in
     Html.Styled.form
-        ((Form.listeners options_.id
+        ((Form.listeners options_.id eventHandlers
             |> List.map (Attr.map (Internal.FieldEvent.FormFieldEvent >> formState.toMsg))
             |> List.map StyledAttr.fromUnstyled
          )
@@ -1304,7 +1312,7 @@ helperValues :
             }
             parsed
             input
-    -> { hiddenInputs : List view, children : List view, isValid : Bool, parsed : Maybe parsed, fields : List ( String, String ), errors : Dict String (List error) }
+    -> { hiddenInputs : List view, children : List view, isValid : Bool, parsed : Maybe parsed, fields : List ( String, String ), errors : Dict String (List error), eventHandlers : Dict String Pages.Internal.Form.EventHandler }
 helperValues options_ toHiddenInput formState (Internal.Form.Form fieldDefinitions parser toInitialValues) =
     let
         initialValues : Dict String FieldState
@@ -1457,7 +1465,7 @@ helperValues options_ toHiddenInput formState (Internal.Form.Form fieldDefinitio
         isValid : Bool
         isValid =
             case withoutServerErrors of
-                Validation _ _ ( Just _, errors ) ->
+                Validation _ _ ( Just _, errors ) _ ->
                     Dict.isEmpty errors
 
                 _ ->
@@ -1465,8 +1473,14 @@ helperValues options_ toHiddenInput formState (Internal.Form.Form fieldDefinitio
 
         ( maybeParsed, errorsDict ) =
             case withoutServerErrors of
-                Validation _ _ ( parsedValue, errors ) ->
+                Validation _ _ ( parsedValue, errors ) _ ->
                     ( parsedValue, errors )
+
+        eventHandlers : Dict String Pages.Internal.Form.EventHandler
+        eventHandlers =
+            case parsed1.combineAndView.combine of
+                Validation _ _ _ handlers ->
+                    handlers
     in
     { hiddenInputs = hiddenInputs
     , children = children
@@ -1474,6 +1488,7 @@ helperValues options_ toHiddenInput formState (Internal.Form.Form fieldDefinitio
     , parsed = maybeParsed
     , fields = rawFields
     , errors = errorsDict
+    , eventHandlers = eventHandlers
     }
 
 
@@ -1708,7 +1723,7 @@ updateForm fieldEvent formState =
                         (case fieldEvent.event of
                             InputEvent newValue ->
                                 { previousValue
-                                    | value = newValue
+                                    | value = fieldEvent.value
                                     , status = previousValue.status |> increaseStatusTo Form.Validation.Changed
                                 }
 
@@ -1720,7 +1735,10 @@ updateForm fieldEvent formState =
                                 }
 
                             BlurEvent ->
-                                { previousValue | status = previousValue.status |> increaseStatusTo Form.Validation.Blurred }
+                                { previousValue
+                                    | status = previousValue.status |> increaseStatusTo Form.Validation.Blurred
+                                    , value = fieldEvent.value
+                                }
                         )
                             |> Just
                     )

--- a/src/Form/Field.elm
+++ b/src/Form/Field.elm
@@ -6,6 +6,7 @@ module Form.Field exposing
     , withInitialValue, withOptionalInitialValue
     , exactValue
     , required, validateMap, map
+    , formatOnEvent, EventInfo(..)
     , email, password, search, telephone, url, textarea
     , range, withMin, withMax
     , withMinLength, withMaxLength
@@ -48,6 +49,11 @@ module Form.Field exposing
 @docs required, validateMap, map
 
 
+## Event Formatting
+
+@docs formatOnEvent, EventInfo
+
+
 ## Text Field Display Options
 
 @docs email, password, search, telephone, url, textarea
@@ -70,6 +76,7 @@ module Form.Field exposing
 
 import Date exposing (Date)
 import Dict exposing (Dict)
+import Form.Field.Selection exposing (Selection)
 import Form.FieldView exposing (Input)
 import Internal.Field
 import Internal.Input exposing (Options(..))
@@ -267,6 +274,85 @@ required missingError (Internal.Field.Field field kind) =
         , properties =
             ( "required", Encode.bool True ) :: field.properties
         , compare = field.compare
+        , formatOnEvent = field.formatOnEvent
+        }
+        kind
+
+
+{-| The event that triggered a [`formatOnEvent`](#formatOnEvent) callback.
+
+  - `Input` - the user typed or pasted. Carries a [`Selection`](Form-Field-Selection) with the value and cursor position, so you can decide whether to reformat.
+  - `Blur` - the field lost focus. Carries the current value as a `String`. Good place to do cleanup like trimming whitespace.
+  - `Focus` - the field gained focus. Carries the current value as a `String`.
+
+-}
+type EventInfo
+    = Input Selection
+    | Blur String
+    | Focus String
+
+
+{-| Transform a field's value when an event fires. Return `Just newValue` to update, `Nothing` to leave it alone.
+
+For example, formatting an expiration date as the user types (`1225` becomes `12 / 25`):
+
+    import Form.Field as Field exposing (EventInfo(..))
+    import Form.Field.Selection as Selection
+
+    Field.text
+        |> Field.formatOnEvent
+            (\event ->
+                case event of
+                    Input selection ->
+                        if Selection.cursorAtEnd selection then
+                            Just (formatExpDate (Selection.value selection))
+                        else
+                            -- don't reformat while editing the middle
+                            Nothing
+
+                    _ ->
+                        Nothing
+            )
+
+    formatExpDate : String -> String
+    formatExpDate raw =
+        let
+            digits =
+                String.filter Char.isDigit raw
+                    |> String.left 4
+        in
+        if String.length digits > 2 then
+            String.left 2 digits ++ " / " ++ String.dropLeft 2 digits
+        else
+            digits
+
+The [`Selection`](Form-Field-Selection) check matters because reformatting moves the cursor to the
+end. If the user clicks back to fix a typo, you want to leave the value alone until they're
+typing at the end again.
+
+-}
+formatOnEvent : (EventInfo -> Maybe String) -> Field error parsed input initial kind constraints -> Field error parsed input initial kind constraints
+formatOnEvent formatter (Internal.Field.Field field kind) =
+    Internal.Field.Field
+        { field
+            | formatOnEvent =
+                Just
+                    (\internalEvent ->
+                        -- Convert Internal.Field.EventInfo to Form.Field.EventInfo
+                        let
+                            publicEvent =
+                                case internalEvent of
+                                    Internal.Field.Input selection ->
+                                        Input selection
+
+                                    Internal.Field.Blur value ->
+                                        Blur value
+
+                                    Internal.Field.Focus value ->
+                                        Focus value
+                        in
+                        formatter publicEvent
+                    )
         }
         kind
 
@@ -323,6 +409,7 @@ text =
                 )
         , properties = []
         , compare = Basics.compare
+        , formatOnEvent = Nothing
         }
         (Internal.Input.Input Internal.Input.Text)
 
@@ -375,6 +462,7 @@ date toError =
                         Err error ->
                             ( Nothing, [ error ] )
         , properties = []
+        , formatOnEvent = Nothing
         , compare =
             \raw value ->
                 Result.map2 Date.compare
@@ -440,6 +528,7 @@ time toError =
                         Err error ->
                             ( Nothing, [ error ] )
         , properties = []
+        , formatOnEvent = Nothing
         , compare =
             \raw value ->
                 parseTimeOfDay raw
@@ -617,6 +706,7 @@ select optionsMapping invalidError =
                                   ]
                                 )
         , properties = []
+        , formatOnEvent = Nothing
         , compare =
             \_ _ ->
                 -- min/max properties aren't allowed for this field type
@@ -663,6 +753,7 @@ exactValue initialValue error =
                 else
                     ( rawValue, [ error ] )
         , properties = []
+        , formatOnEvent = Nothing
         , compare =
             \_ _ ->
                 -- min/max properties aren't allowed for this field type
@@ -705,6 +796,7 @@ checkbox =
                 , []
                 )
         , properties = []
+        , formatOnEvent = Nothing
         , compare =
             \_ _ ->
                 -- min/max properties aren't allowed for this field type
@@ -762,6 +854,7 @@ int toError =
                             Nothing ->
                                 ( Nothing, [ toError.invalid string ] )
         , properties = []
+        , formatOnEvent = Nothing
         , compare =
             \raw value ->
                 case String.toInt raw of
@@ -823,6 +916,7 @@ float toError =
                             Nothing ->
                                 ( Nothing, [ toError.invalid string ] )
         , properties = []
+        , formatOnEvent = Nothing
         , compare =
             \raw value ->
                 case String.toFloat raw of
@@ -1122,6 +1216,7 @@ validateMap_ mapFn (Internal.Field.Field field kind) =
                                         |> Tuple.mapSecond ((++) errors)
                        )
         , properties = field.properties
+        , formatOnEvent = field.formatOnEvent
         , compare = field.compare
         }
         kind
@@ -1175,6 +1270,7 @@ withMin min error (Internal.Field.Field field kind) =
                                                 ( Just okValue, errors )
                        )
         , properties = ( "min", Encode.string (field.initialToString min) ) :: field.properties
+        , formatOnEvent = field.formatOnEvent
         , compare = field.compare
         }
         kind
@@ -1204,6 +1300,7 @@ withMinLength minLength error (Internal.Field.Field field kind) =
                                         ( Just okValue, error :: errors )
                        )
         , properties = ( "minlength", Encode.string (String.fromInt minLength) ) :: field.properties
+        , formatOnEvent = field.formatOnEvent
         , compare = field.compare
         }
         kind
@@ -1233,6 +1330,7 @@ withMaxLength maxLength error (Internal.Field.Field field kind) =
                                         ( Just okValue, error :: errors )
                        )
         , properties = ( "maxlength", Encode.string (String.fromInt maxLength) ) :: field.properties
+        , formatOnEvent = field.formatOnEvent
         , compare = field.compare
         }
         kind
@@ -1290,6 +1388,7 @@ withMax max error (Internal.Field.Field field kind) =
                                                 ( Just okValue, errors )
                        )
         , properties = ( "max", Encode.string (field.initialToString max) ) :: field.properties
+        , formatOnEvent = field.formatOnEvent
         , compare = field.compare
         }
         kind

--- a/src/Form/Field/Selection.elm
+++ b/src/Form/Field/Selection.elm
@@ -1,0 +1,134 @@
+module Form.Field.Selection exposing
+    ( Selection
+    , value, cursorPosition, cursorAtEnd
+    , zipper, SelectionZipper(..)
+    )
+
+{-| When formatting a field as the user types (e.g. an expiration date `12 / 25` or a phone number
+`(555) 123-4567`), you need to know where the cursor is. Without it, reformatting the value can
+jump the cursor to the end, which breaks editing when the user goes back to fix a typo.
+
+`Selection` gives you the field value _and_ the cursor position so you can decide whether it's
+safe to reformat. The most common pattern is to only format when the cursor is at the end:
+
+    import Form.Field as Field exposing (EventInfo(..))
+    import Form.Field.Selection as Selection
+
+    Field.text
+        |> Field.formatOnEvent
+            (\event ->
+                case event of
+                    Input selection ->
+                        if Selection.cursorAtEnd selection then
+                            Just (formatExpDate (Selection.value selection))
+                        else
+                            Nothing
+
+                    _ ->
+                        Nothing
+            )
+
+You get a `Selection` from the `Input` variant of [`EventInfo`](Form-Field#EventInfo).
+
+@docs Selection
+
+@docs value, cursorPosition, cursorAtEnd
+
+
+## Zipper Representation
+
+For more advanced formatting where you need to know what's before and after the cursor:
+
+@docs zipper, SelectionZipper
+
+-}
+
+import Internal.Selection
+
+
+{-| The field value plus cursor position. You get this from the `Input` variant of
+[`EventInfo`](Form-Field#EventInfo) when using [`formatOnEvent`](Form-Field#formatOnEvent).
+-}
+type alias Selection =
+    Internal.Selection.Selection
+
+
+{-| The full string value of the field. Use this to read what the user has typed so far.
+-}
+value : Selection -> String
+value (Internal.Selection.Selection val _) =
+    val
+
+
+{-| Raw cursor/selection position as `( selectionStart, selectionEnd )`.
+
+  - `( start, Nothing )` - cursor at position `start`, no text selected
+  - `( start, Just end )` - text selected from `start` to `end`
+
+Most of the time [`cursorAtEnd`](#cursorAtEnd) is all you need.
+
+-}
+cursorPosition : Selection -> ( Int, Maybe Int )
+cursorPosition (Internal.Selection.Selection _ pos) =
+    pos
+
+
+{-| `True` when the cursor is at the end with nothing selected. This is usually when it's
+safe to reformat without messing up the user's cursor position:
+
+    Input selection ->
+        if Selection.cursorAtEnd selection then
+            Just (format (Selection.value selection))
+        else
+            Nothing
+
+-}
+cursorAtEnd : Selection -> Bool
+cursorAtEnd (Internal.Selection.Selection val ( start, maybeEnd )) =
+    case maybeEnd of
+        Nothing ->
+            start == String.length val
+
+        Just end ->
+            start == end && end == String.length val
+
+
+{-| Splits the field value into parts around the cursor or selection.
+
+  - `Cursor { before, after }` - nothing selected, cursor sits between `before` and `after`
+  - `Range { before, selected, after }` - user has highlighted `selected`
+
+-}
+type SelectionZipper
+    = Cursor { before : String, after : String }
+    | Range { before : String, selected : String, after : String }
+
+
+{-| Break the selection into a [`SelectionZipper`](#SelectionZipper).
+
+Useful when you need to know what's on either side of the cursor, like checking if the text
+before the cursor already ends with a separator before inserting another one.
+
+-}
+zipper : Selection -> SelectionZipper
+zipper (Internal.Selection.Selection val ( start, maybeEnd )) =
+    case maybeEnd of
+        Nothing ->
+            Cursor
+                { before = String.left start val
+                , after = String.dropLeft start val
+                }
+
+        Just end ->
+            if start == end then
+                Cursor
+                    { before = String.left start val
+                    , after = String.dropLeft start val
+                    }
+
+            else
+                Range
+                    { before = String.left start val
+                    , selected = String.slice start end val
+                    , after = String.dropLeft end val
+                    }

--- a/src/Form/FieldView.elm
+++ b/src/Form/FieldView.elm
@@ -61,7 +61,7 @@ valueButton :
     -> List (Html msg)
     -> Form.Validation.Field error parsed kind
     -> Html msg
-valueButton exactValue attrs children (Validation viewField fieldName _) =
+valueButton exactValue attrs children (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField kind
         justViewField =
@@ -95,7 +95,7 @@ valueButtonStyled :
     -> List (Html.Styled.Html msg)
     -> Form.Validation.Field error parsed kind
     -> Html.Styled.Html msg
-valueButtonStyled exactValue attrs children (Validation viewField fieldName _) =
+valueButtonStyled exactValue attrs children (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField kind
         justViewField =
@@ -166,7 +166,7 @@ input :
     List (Html.Attribute msg)
     -> Form.Validation.Field error parsed Input
     -> Html msg
-input attrs (Validation viewField fieldName _) =
+input attrs (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField Input
         justViewField =
@@ -221,7 +221,7 @@ inputStyled :
     List (Html.Styled.Attribute msg)
     -> Form.Validation.Field error parsed Input
     -> Html.Styled.Html msg
-inputStyled attrs (Validation viewField fieldName _) =
+inputStyled attrs (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField Input
         justViewField =
@@ -317,7 +317,7 @@ select :
         )
     -> Form.Validation.Field error parsed2 (Options parsed)
     -> Html msg
-select selectAttrs enumToOption (Validation viewField fieldName _) =
+select selectAttrs enumToOption (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField (Options parsed)
         justViewField =
@@ -383,7 +383,7 @@ selectStyled :
         )
     -> Form.Validation.Field error parsed2 (Options parsed)
     -> Html.Styled.Html msg
-selectStyled selectAttrs enumToOption (Validation viewField fieldName _) =
+selectStyled selectAttrs enumToOption (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField (Options parsed)
         justViewField =
@@ -492,7 +492,7 @@ radio :
         )
     -> Form.Validation.Field error parsed2 (Options option)
     -> Html msg
-radio selectAttrs enumToOption (Validation viewField fieldName _) =
+radio selectAttrs enumToOption (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField (Options option)
         justViewField =
@@ -570,7 +570,7 @@ radioStyled :
         )
     -> Form.Validation.Field error parsed2 (Options parsed)
     -> Html.Styled.Html msg
-radioStyled selectAttrs enumToOption (Validation viewField fieldName _) =
+radioStyled selectAttrs enumToOption (Validation viewField fieldName _ _) =
     let
         justViewField : ViewField (Options parsed)
         justViewField =

--- a/src/Form/Handler.elm
+++ b/src/Form/Handler.elm
@@ -314,7 +314,7 @@ mergeResults :
     -> Validation error parsed unnamed constraints2
 mergeResults parsed =
     let
-        ( Pages.Internal.Form.Validation _ name ( parsedThing, combineErrors ), individualFieldErrors ) =
+        ( Pages.Internal.Form.Validation _ name ( parsedThing, combineErrors ) handlers, individualFieldErrors ) =
             parsed.result
     in
     Pages.Internal.Form.Validation Nothing
@@ -322,10 +322,11 @@ mergeResults parsed =
         ( parsedThing
         , mergeErrors combineErrors individualFieldErrors
         )
+        handlers
 
 
 unwrapValidation : Validation error parsed named constraints -> ( Maybe parsed, Dict String (List error) )
-unwrapValidation (Pages.Internal.Form.Validation _ _ ( maybeParsed, errors )) =
+unwrapValidation (Pages.Internal.Form.Validation _ _ ( maybeParsed, errors ) _) =
     ( maybeParsed, errors )
 
 

--- a/src/Form/Validation.elm
+++ b/src/Form/Validation.elm
@@ -78,7 +78,7 @@ type alias Validation error parsed kind constraints =
 {-| Get the `Field`'s name.
 -}
 fieldName : Field error parsed kind -> String
-fieldName (Pages.Internal.Form.Validation _ name _) =
+fieldName (Pages.Internal.Form.Validation _ name _ _) =
     name
         |> Maybe.withDefault ""
 
@@ -86,7 +86,7 @@ fieldName (Pages.Internal.Form.Validation _ name _) =
 {-| Get the `Field`'s [`FieldStatus`](#FieldStatus).
 -}
 fieldStatus : Field error parsed kind -> FieldStatus
-fieldStatus (Pages.Internal.Form.Validation viewField _ _) =
+fieldStatus (Pages.Internal.Form.Validation viewField _ _ _) =
     viewField
         |> Maybe.map .status
         |> Maybe.withDefault 0
@@ -200,7 +200,7 @@ for an example of a common idiom.
 -}
 succeed : parsed -> Validation error parsed kind constraints
 succeed parsed =
-    Pages.Internal.Form.Validation Nothing Nothing ( Just parsed, Dict.empty )
+    Pages.Internal.Form.Validation Nothing Nothing ( Just parsed, Dict.empty ) Dict.empty
 
 
 {-| A `Field` that represents the form as a whole. This is useful for attaching validation errors to the form as a whole rather than to a specific field.
@@ -212,13 +212,14 @@ global =
         ( Just ()
         , Dict.empty
         )
+        Dict.empty
 
 
 {-| Include a fallback value to parse into. Does not remove any previous validation errors that have been encountered
 so it will not effect whether it parses to `Valid` or `Invalid`.
 -}
 withFallback : parsed -> Validation error parsed named constraints -> Validation error parsed named constraints
-withFallback parsed (Pages.Internal.Form.Validation viewField name ( maybeParsed, errors )) =
+withFallback parsed (Pages.Internal.Form.Validation viewField name ( maybeParsed, errors ) handlers) =
     Pages.Internal.Form.Validation viewField
         name
         ( maybeParsed
@@ -226,12 +227,13 @@ withFallback parsed (Pages.Internal.Form.Validation viewField name ( maybeParsed
             |> Just
         , errors
         )
+        handlers
 
 
 {-| Get the parsed value if it is parseable (could be either invalid or valid).
 -}
 value : Validation error parsed named constraint -> Maybe parsed
-value (Pages.Internal.Form.Validation _ _ ( maybeParsed, _ )) =
+value (Pages.Internal.Form.Validation _ _ ( maybeParsed, _ ) _) =
     maybeParsed
 
 
@@ -244,15 +246,15 @@ See [`withError`](#withError) if you want to add an error without short-circuiti
 
 -}
 fail : error -> Field error parsed1 field -> Validation error parsed kind constraints
-fail parsed (Pages.Internal.Form.Validation _ key _) =
-    Pages.Internal.Form.Validation Nothing Nothing ( Nothing, Dict.singleton (key |> Maybe.withDefault "") [ parsed ] )
+fail parsed (Pages.Internal.Form.Validation _ key _ handlers) =
+    Pages.Internal.Form.Validation Nothing Nothing ( Nothing, Dict.singleton (key |> Maybe.withDefault "") [ parsed ] ) handlers
 
 
 {-| Add an error to the given `Field`.
 -}
 withError : Field error parsed1 field -> error -> Validation error parsed2 named constraints -> Validation error parsed2 named constraints
-withError (Pages.Internal.Form.Validation _ key _) error (Pages.Internal.Form.Validation viewField name ( maybeParsedA, errorsA )) =
-    Pages.Internal.Form.Validation viewField name ( maybeParsedA, errorsA |> insertIfNonempty (key |> Maybe.withDefault "") [ error ] )
+withError (Pages.Internal.Form.Validation _ key _ _) error (Pages.Internal.Form.Validation viewField name ( maybeParsedA, errorsA ) handlers) =
+    Pages.Internal.Form.Validation viewField name ( maybeParsedA, errorsA |> insertIfNonempty (key |> Maybe.withDefault "") [ error ] ) handlers
 
 
 {-| Conditionally add an error to the given `Field`.
@@ -275,7 +277,7 @@ withError (Pages.Internal.Form.Validation _ key _) error (Pages.Internal.Form.Va
 
 -}
 withErrorIf : Bool -> Field error ignored field -> error -> Validation error parsed named constraints -> Validation error parsed named constraints
-withErrorIf includeError (Pages.Internal.Form.Validation _ key _) error (Pages.Internal.Form.Validation viewField name ( maybeParsedA, errorsA )) =
+withErrorIf includeError (Pages.Internal.Form.Validation _ key _ _) error (Pages.Internal.Form.Validation viewField name ( maybeParsedA, errorsA ) handlers) =
     Pages.Internal.Form.Validation viewField
         name
         ( maybeParsedA
@@ -285,6 +287,7 @@ withErrorIf includeError (Pages.Internal.Form.Validation _ key _) error (Pages.I
           else
             errorsA
         )
+        handlers
 
 
 {-| Apply a function to the parsed value.
@@ -307,8 +310,8 @@ withErrorIf includeError (Pages.Internal.Form.Validation _ key _) error (Pages.I
 
 -}
 map : (parsed -> mapped) -> Validation error parsed named constraint -> Validation error mapped erasedKind erasedConstraints
-map mapFn (Pages.Internal.Form.Validation _ name ( maybeParsedA, errorsA )) =
-    Pages.Internal.Form.Validation Nothing name ( Maybe.map mapFn maybeParsedA, errorsA )
+map mapFn (Pages.Internal.Form.Validation _ name ( maybeParsedA, errorsA ) handlers) =
+    Pages.Internal.Form.Validation Nothing name ( Maybe.map mapFn maybeParsedA, errorsA ) handlers
 
 
 {-| Resolve a `Result` within a `Field`. If it is `Err`, the error will be added to the `Field`'s errors.
@@ -396,16 +399,16 @@ andMap =
 
 -}
 andThen : (parsed -> Validation error mapped named1 constraints1) -> Validation error parsed named2 constraints2 -> Validation error mapped Never constraintsAny
-andThen andThenFn (Pages.Internal.Form.Validation _ _ ( maybeParsed, errors )) =
+andThen andThenFn (Pages.Internal.Form.Validation _ _ ( maybeParsed, errors ) handlers) =
     case maybeParsed of
         Just parsed ->
             andThenFn parsed
-                |> (\(Pages.Internal.Form.Validation _ _ ( andThenParsed, andThenErrors )) ->
-                        Pages.Internal.Form.Validation Nothing Nothing ( andThenParsed, mergeErrors errors andThenErrors )
+                |> (\(Pages.Internal.Form.Validation _ _ ( andThenParsed, andThenErrors ) andThenHandlers) ->
+                        Pages.Internal.Form.Validation Nothing Nothing ( andThenParsed, mergeErrors errors andThenErrors ) (Dict.union andThenHandlers handlers)
                    )
 
         Nothing ->
-            Pages.Internal.Form.Validation Nothing Nothing ( Nothing, errors )
+            Pages.Internal.Form.Validation Nothing Nothing ( Nothing, errors ) handlers
 
 
 {-| Combine together two `Validation`'s.
@@ -429,12 +432,13 @@ andThen andThenFn (Pages.Internal.Form.Validation _ _ ( maybeParsed, errors )) =
 
 -}
 map2 : (a -> b -> c) -> Validation error a named1 constraints1 -> Validation error b named2 constraints2 -> Validation error c Never constraintsAny
-map2 f (Pages.Internal.Form.Validation _ _ ( maybeParsedA, errorsA )) (Pages.Internal.Form.Validation _ _ ( maybeParsedB, errorsB )) =
+map2 f (Pages.Internal.Form.Validation _ _ ( maybeParsedA, errorsA ) handlersA) (Pages.Internal.Form.Validation _ _ ( maybeParsedB, errorsB ) handlersB) =
     Pages.Internal.Form.Validation Nothing
         Nothing
         ( Maybe.map2 f maybeParsedA maybeParsedB
         , mergeErrors errorsA errorsB
         )
+        (Dict.union handlersA handlersB)
 
 
 {-| -}

--- a/src/Internal/Field.elm
+++ b/src/Internal/Field.elm
@@ -1,7 +1,8 @@
-module Internal.Field exposing (Field(..), FieldInfo)
+module Internal.Field exposing (EventInfo(..), Field(..), FieldInfo)
 
 {-| -}
 
+import Form.Field.Selection as Selection exposing (Selection)
 import Json.Encode as Encode
 
 
@@ -16,4 +17,12 @@ type alias FieldInfo error parsed input initial =
     , properties : List ( String, Encode.Value )
     , initialToString : initial -> String
     , compare : String -> initial -> Order
+    , formatOnEvent : Maybe (EventInfo -> Maybe String)
     }
+
+
+{-| -}
+type EventInfo
+    = Input Selection
+    | Blur String
+    | Focus String

--- a/src/Internal/Selection.elm
+++ b/src/Internal/Selection.elm
@@ -1,0 +1,8 @@
+module Internal.Selection exposing (Selection(..))
+
+{-| -}
+
+
+{-| -}
+type Selection
+    = Selection String ( Int, Maybe Int )

--- a/src/Pages/FormState.elm
+++ b/src/Pages/FormState.elm
@@ -4,24 +4,33 @@ import Dict exposing (Dict)
 import Html exposing (Attribute)
 import Html.Attributes as Attr
 import Html.Events
+import Internal.Field exposing (EventInfo)
 import Internal.FieldEvent exposing (Event(..), FieldEvent)
+import Internal.Selection exposing (Selection(..))
 import Json.Decode as Decode exposing (Decoder)
 
 
 {-| -}
-listeners : String -> List (Attribute FieldEvent)
-listeners formId =
-    [ Html.Events.on "focusin" fieldEventDecoder
-    , Html.Events.on "focusout" fieldEventDecoder
-    , Html.Events.on "input" fieldEventDecoder
+listeners : String -> Dict String (EventInfo -> Maybe String) -> List (Attribute FieldEvent)
+listeners formId eventHandlers =
+    [ Html.Events.on "focusin" (fieldEventDecoder eventHandlers)
+    , Html.Events.on "focusout" (fieldEventDecoder eventHandlers)
+    , Html.Events.on "input" (fieldEventDecoder eventHandlers)
     , Attr.id formId
     ]
 
 
 {-| -}
-fieldEventDecoder : Decoder FieldEvent
-fieldEventDecoder =
-    Decode.map4 FieldEvent
+fieldEventDecoder : Dict String (EventInfo -> Maybe String) -> Decoder FieldEvent
+fieldEventDecoder eventHandlers =
+    Decode.map4
+        (\value formId name selection ->
+            { value = value
+            , formId = formId
+            , name = name
+            , selection = selection
+            }
+        )
         inputValueDecoder
         (Decode.at [ "currentTarget", "id" ] Decode.string)
         (Decode.at [ "target", "name" ] Decode.string
@@ -34,7 +43,58 @@ fieldEventDecoder =
                         Decode.succeed name
                 )
         )
-        fieldDecoder
+        selectionDecoder
+        |> Decode.andThen
+            (\partial ->
+                fieldDecoder
+                    |> Decode.map
+                        (\event ->
+                            let
+                                eventInfo : EventInfo
+                                eventInfo =
+                                    case event of
+                                        InputEvent _ ->
+                                            Internal.Field.Input partial.selection
+
+                                        BlurEvent ->
+                                            Internal.Field.Blur partial.value
+
+                                        FocusEvent ->
+                                            Internal.Field.Focus partial.value
+
+                                newValue : Maybe String
+                                newValue =
+                                    Dict.get partial.name eventHandlers
+                                        |> Maybe.andThen (\handler -> handler eventInfo)
+                            in
+                            { value =
+                                case newValue of
+                                    Just formatted ->
+                                        formatted
+
+                                    Nothing ->
+                                        partial.value
+                            , formId = partial.formId
+                            , name = partial.name
+                            , event = event
+                            }
+                        )
+            )
+
+
+{-| Decode selection data (selectionStart and selectionEnd) from the input event.
+On blur events, selectionStart might be null, so we default to 0.
+-}
+selectionDecoder : Decoder Selection
+selectionDecoder =
+    Decode.map2 Selection
+        (Decode.at [ "target", "value" ] Decode.string)
+        (Decode.map2 Tuple.pair
+            (Decode.maybe (Decode.at [ "target", "selectionStart" ] Decode.int)
+                |> Decode.map (Maybe.withDefault 0)
+            )
+            (Decode.maybe (Decode.at [ "target", "selectionEnd" ] Decode.int))
+        )
 
 
 {-| -}

--- a/src/Pages/Internal/Form.elm
+++ b/src/Pages/Internal/Form.elm
@@ -1,12 +1,18 @@
-module Pages.Internal.Form exposing (Validation(..), ViewField)
+module Pages.Internal.Form exposing (EventHandler, Validation(..), ViewField)
 
 import Dict exposing (Dict)
 import Form.FieldStatus exposing (FieldStatus)
+import Internal.Field
 import Json.Encode as Encode
 
 
+{-| -}
+type alias EventHandler =
+    Internal.Field.EventInfo -> Maybe String
+
+
 type Validation error parsed kind field
-    = Validation (Maybe (ViewField kind)) (Maybe String) ( Maybe parsed, Dict String (List error) )
+    = Validation (Maybe (ViewField kind)) (Maybe String) ( Maybe parsed, Dict String (List error) ) (Dict String EventHandler)
 
 
 {-| -}

--- a/tests/FormTests.elm
+++ b/tests/FormTests.elm
@@ -260,16 +260,20 @@ all =
                             (fields
                                 [ ( "password", "mypassword" )
                                 , ( "password-confirmation", "doesnt-match" )
+                                , ( "_subform", "default" )
                                 ]
                             )
                             (Form.form
-                                (\postForm_ ->
+                                (\subformType postForm_ ->
                                     { combine =
-                                        postForm_.combine ()
+                                        subformType
+                                            |> Validation.andThen (\_ -> postForm_.combine ())
                                     , view =
                                         \_ -> ( [], [ Div ] )
                                     }
                                 )
+                                |> Form.hiddenField "_subform"
+                                    (Field.exactValue "default" "Invalid")
                                 |> Form.dynamic
                                     (\() ->
                                         Form.form
@@ -845,6 +849,772 @@ all =
                                     )
                                 )
                 ]
+            ]
+        , describe "formatOnEvent"
+            [ test "field with formatOnEvent parses correctly" <|
+                \() ->
+                    let
+                        uppercaseOnBlur : Field.EventInfo -> Maybe String
+                        uppercaseOnBlur event =
+                            case event of
+                                Field.Blur val ->
+                                    Just (String.toUpper val)
+
+                                _ ->
+                                    Nothing
+
+                        formWithFormat : DoneForm String String input MyView
+                        formWithFormat =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent uppercaseOnBlur
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields
+                            [ ( "name", "hello" ) ]
+                        )
+                        (formWithFormat |> Form.Handler.init identity)
+                        |> Expect.equal (Valid "hello")
+            , test "multiple fields with formatOnEvent parse correctly" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithMultipleFormatters : DoneForm String ( String, String ) input MyView
+                        formWithMultipleFormatters =
+                            Form.form
+                                (\first last ->
+                                    { combine =
+                                        Validation.succeed Tuple.pair
+                                            |> Validation.andMap first
+                                            |> Validation.andMap last
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "first"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                                |> Form.field "last"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields
+                            [ ( "first", "Jane" )
+                            , ( "last", "Doe" )
+                            ]
+                        )
+                        (formWithMultipleFormatters |> Form.Handler.init identity)
+                        |> Expect.equal (Valid ( "Jane", "Doe" ))
+            , test "field with formatOnEvent still produces validation errors" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithFormat : DoneForm String String input MyView
+                        formWithFormat =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields [])
+                        (formWithFormat |> Form.Handler.init identity)
+                        |> Expect.equal
+                            (Invalid Nothing
+                                (Dict.fromList [ ( "name", [ "Required" ] ) ])
+                            )
+            , test "dynamic sub-form with formatOnEvent parses correctly" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        linkFormWithFormat : DoneForm String PostAction input MyView
+                        linkFormWithFormat =
+                            Form.form
+                                (\url ->
+                                    { combine =
+                                        Validation.succeed ParsedLink
+                                            |> Validation.andMap url
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "url"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.url
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+
+                        postFormWithFormat : DoneForm String PostAction input MyView
+                        postFormWithFormat =
+                            Form.form
+                                (\title body ->
+                                    { combine =
+                                        Validation.succeed
+                                            (\titleValue bodyValue ->
+                                                { title = titleValue
+                                                , body = bodyValue
+                                                }
+                                            )
+                                            |> Validation.andMap title
+                                            |> Validation.andMap body
+                                            |> Validation.map ParsedPost
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "title"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                                |> Form.field "body" Field.text
+
+                        dynamicFormWithFormat : DoneForm String PostAction input MyView
+                        dynamicFormWithFormat =
+                            Form.form
+                                (\kind postForm_ ->
+                                    { combine =
+                                        kind
+                                            |> Validation.andThen postForm_.combine
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "kind"
+                                    (Field.select
+                                        [ ( "link", Link )
+                                        , ( "post", Post )
+                                        ]
+                                        (\_ -> "Invalid")
+                                        |> Field.required "Required"
+                                    )
+                                |> Form.dynamic
+                                    (\parsedKind ->
+                                        case parsedKind of
+                                            Link ->
+                                                linkFormWithFormat
+
+                                            Post ->
+                                                postFormWithFormat
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields
+                            [ ( "kind", "link" )
+                            , ( "url", "https://elm-radio.com" )
+                            ]
+                        )
+                        (dynamicFormWithFormat |> Form.Handler.init identity)
+                        |> Expect.equal (Valid (ParsedLink "https://elm-radio.com"))
+            , test "dynamic sub-form with formatOnEvent includes errors" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        linkFormWithFormat : DoneForm String PostAction input MyView
+                        linkFormWithFormat =
+                            Form.form
+                                (\url ->
+                                    { combine =
+                                        Validation.succeed ParsedLink
+                                            |> Validation.andMap url
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "url"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.url
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+
+                        dynamicFormWithFormat : DoneForm String PostAction input MyView
+                        dynamicFormWithFormat =
+                            Form.form
+                                (\kind postForm_ ->
+                                    { combine =
+                                        kind
+                                            |> Validation.andThen postForm_.combine
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "kind"
+                                    (Field.select
+                                        [ ( "link", Link )
+                                        , ( "post", Post )
+                                        ]
+                                        (\_ -> "Invalid")
+                                        |> Field.required "Required"
+                                    )
+                                |> Form.dynamic
+                                    (\parsedKind ->
+                                        case parsedKind of
+                                            Link ->
+                                                linkFormWithFormat
+
+                                            Post ->
+                                                linkFormWithFormat
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields
+                            [ ( "kind", "link" ) ]
+                        )
+                        (dynamicFormWithFormat |> Form.Handler.init identity)
+                        |> Expect.equal
+                            (Invalid Nothing
+                                (Dict.fromList [ ( "url", [ "Required" ] ) ])
+                            )
+            , test "dynamic sub-form switching with formatOnEvent parses both branches" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        linkFormWithFormat : DoneForm String PostAction input MyView
+                        linkFormWithFormat =
+                            Form.form
+                                (\url ->
+                                    { combine =
+                                        Validation.succeed ParsedLink
+                                            |> Validation.andMap url
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "url"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.url
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+
+                        postFormWithFormat : DoneForm String PostAction input MyView
+                        postFormWithFormat =
+                            Form.form
+                                (\title body ->
+                                    { combine =
+                                        Validation.succeed
+                                            (\titleValue bodyValue ->
+                                                { title = titleValue
+                                                , body = bodyValue
+                                                }
+                                            )
+                                            |> Validation.andMap title
+                                            |> Validation.andMap body
+                                            |> Validation.map ParsedPost
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "title"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                                |> Form.field "body" Field.text
+
+                        dynamicFormWithFormat : DoneForm String PostAction input MyView
+                        dynamicFormWithFormat =
+                            Form.form
+                                (\kind postForm_ ->
+                                    { combine =
+                                        kind
+                                            |> Validation.andThen postForm_.combine
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "kind"
+                                    (Field.select
+                                        [ ( "link", Link )
+                                        , ( "post", Post )
+                                        ]
+                                        (\_ -> "Invalid")
+                                        |> Field.required "Required"
+                                    )
+                                |> Form.dynamic
+                                    (\parsedKind ->
+                                        case parsedKind of
+                                            Link ->
+                                                linkFormWithFormat
+
+                                            Post ->
+                                                postFormWithFormat
+                                    )
+                    in
+                    -- Test the post branch parses too
+                    Form.Handler.run
+                        (fields
+                            [ ( "kind", "post" )
+                            , ( "title", "My Post" )
+                            , ( "body", "Content here" )
+                            ]
+                        )
+                        (dynamicFormWithFormat |> Form.Handler.init identity)
+                        |> Expect.equal
+                            (Valid
+                                (ParsedPost
+                                    { title = "My Post"
+                                    , body = Just "Content here"
+                                    }
+                                )
+                            )
+            ]
+        , describe "formatOnEvent with Form.parse"
+            [ test "Form.parse with formatOnEvent field" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithFormat =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+
+                        model : Form.Model
+                        model =
+                            Dict.singleton "test-form"
+                                { fields =
+                                    Dict.singleton "name"
+                                        { value = "Alice"
+                                        , status = Validation.NotVisited
+                                        }
+                                , submitAttempted = False
+                                }
+                    in
+                    Form.parse "test-form" model () formWithFormat
+                        |> Expect.equal (Valid "Alice")
+            , test "Form.parse with formatOnEvent and validation error" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithFormat =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+
+                        model : Form.Model
+                        model =
+                            Dict.singleton "test-form"
+                                { fields =
+                                    Dict.singleton "name"
+                                        { value = ""
+                                        , status = Validation.Blurred
+                                        }
+                                , submitAttempted = False
+                                }
+                    in
+                    Form.parse "test-form" model () formWithFormat
+                        |> Expect.equal
+                            (Invalid Nothing
+                                (Dict.fromList [ ( "name", [ "Required" ] ) ])
+                            )
+            , test "Form.parse dynamic sub-form with formatOnEvent" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        linkFormWithFormat : DoneForm String PostAction input MyView
+                        linkFormWithFormat =
+                            Form.form
+                                (\url ->
+                                    { combine =
+                                        Validation.succeed ParsedLink
+                                            |> Validation.andMap url
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "url"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.url
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+
+                        postFormWithFormat : DoneForm String PostAction input MyView
+                        postFormWithFormat =
+                            Form.form
+                                (\title body ->
+                                    { combine =
+                                        Validation.succeed
+                                            (\t b -> { title = t, body = b })
+                                            |> Validation.andMap title
+                                            |> Validation.andMap body
+                                            |> Validation.map ParsedPost
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "title"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                                |> Form.field "body" Field.text
+
+                        dynamicForm =
+                            Form.form
+                                (\kind postForm_ ->
+                                    { combine =
+                                        kind
+                                            |> Validation.andThen postForm_.combine
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "kind"
+                                    (Field.select
+                                        [ ( "link", Link )
+                                        , ( "post", Post )
+                                        ]
+                                        (\_ -> "Invalid")
+                                        |> Field.required "Required"
+                                    )
+                                |> Form.dynamic
+                                    (\parsedKind ->
+                                        case parsedKind of
+                                            Link ->
+                                                linkFormWithFormat
+
+                                            Post ->
+                                                postFormWithFormat
+                                    )
+
+                        model : Form.Model
+                        model =
+                            Dict.singleton "test-form"
+                                { fields =
+                                    Dict.fromList
+                                        [ ( "kind", { value = "post", status = Validation.NotVisited } )
+                                        , ( "title", { value = "Hello", status = Validation.Changed } )
+                                        , ( "body", { value = "World", status = Validation.NotVisited } )
+                                        ]
+                                , submitAttempted = False
+                                }
+                    in
+                    Form.parse "test-form" model () dynamicForm
+                        |> Expect.equal
+                            (Valid
+                                (ParsedPost
+                                    { title = "Hello"
+                                    , body = Just "World"
+                                    }
+                                )
+                            )
+            ]
+        , describe "formatOnEvent with hiddenField"
+            [ test "hiddenField with formatOnEvent parses correctly" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithHiddenFormat =
+                            Form.form
+                                (\visible hidden ->
+                                    { combine =
+                                        Validation.succeed Tuple.pair
+                                            |> Validation.andMap visible
+                                            |> Validation.andMap hidden
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "visible"
+                                    (Field.text |> Field.required "Required")
+                                |> Form.hiddenField "hidden"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields
+                            [ ( "visible", "hello" )
+                            , ( "hidden", "secret" )
+                            ]
+                        )
+                        (formWithHiddenFormat |> Form.Handler.init identity)
+                        |> Expect.equal (Valid ( "hello", "secret" ))
+            , test "hiddenField with formatOnEvent produces errors" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithHiddenFormat =
+                            Form.form
+                                (\visible hidden ->
+                                    { combine =
+                                        Validation.succeed Tuple.pair
+                                            |> Validation.andMap visible
+                                            |> Validation.andMap hidden
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "visible"
+                                    (Field.text |> Field.required "Required")
+                                |> Form.hiddenField "hidden"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields
+                            [ ( "visible", "hello" ) ]
+                        )
+                        (formWithHiddenFormat |> Form.Handler.init identity)
+                        |> Expect.equal
+                            (Invalid Nothing
+                                (Dict.fromList [ ( "hidden", [ "Required" ] ) ])
+                            )
+            ]
+        , describe "formatOnEvent with other field modifiers"
+            [ test "formatOnEvent with withMinLength" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithModifiers =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.withMinLength 3 "Too short"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields [ ( "name", "ab" ) ])
+                        (formWithModifiers |> Form.Handler.init identity)
+                        |> Expect.equal
+                            (Invalid (Just "ab")
+                                (Dict.fromList [ ( "name", [ "Too short" ] ) ])
+                            )
+            , test "formatOnEvent with withMinLength passes when valid" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithModifiers =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> Div
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.withMinLength 3 "Too short"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                    in
+                    Form.Handler.run
+                        (fields [ ( "name", "Alice" ) ])
+                        (formWithModifiers |> Form.Handler.init identity)
+                        |> Expect.equal (Valid "Alice")
+            ]
+        , describe "formatOnEvent with Form.Handler (mixed forms)"
+            [ test "handler with mix of formatOnEvent and non-formatOnEvent forms" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formWithFormat : Form.HtmlForm String String () msg
+                        formWithFormat =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> []
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                                |> Form.hiddenKind ( "kind", "with-format" ) "Expected kind"
+
+                        formWithoutFormat : Form.HtmlForm String String () msg
+                        formWithoutFormat =
+                            Form.form
+                                (\email ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap email
+                                    , view = \_ -> []
+                                    }
+                                )
+                                |> Form.field "email"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                    )
+                                |> Form.hiddenKind ( "kind", "without-format" ) "Expected kind"
+
+                        handler =
+                            Form.Handler.init identity formWithFormat
+                                |> Form.Handler.with identity formWithoutFormat
+                    in
+                    [ Form.Handler.run
+                        (fields
+                            [ ( "kind", "with-format" )
+                            , ( "name", "Alice" )
+                            ]
+                        )
+                        handler
+                        |> Expect.equal (Valid "Alice")
+                    , Form.Handler.run
+                        (fields
+                            [ ( "kind", "without-format" )
+                            , ( "email", "alice@example.com" )
+                            ]
+                        )
+                        handler
+                        |> Expect.equal (Valid "alice@example.com")
+                    ]
+                        |> (\expectations ->
+                                case expectations of
+                                    [ a, b ] ->
+                                        Expect.all
+                                            [ \() -> a
+                                            , \() -> b
+                                            ]
+                                            ()
+
+                                    _ ->
+                                        Expect.fail "unreachable"
+                           )
+            ]
+        , describe "formatOnEvent with hiddenKind"
+            [ test "hiddenKind form with formatOnEvent fields parses via Handler" <|
+                \() ->
+                    let
+                        noOpFormatter : Field.EventInfo -> Maybe String
+                        noOpFormatter _ =
+                            Nothing
+
+                        formA : Form.HtmlForm String String () msg
+                        formA =
+                            Form.form
+                                (\name ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap name
+                                    , view = \_ -> []
+                                    }
+                                )
+                                |> Form.field "name"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                                |> Form.hiddenKind ( "kind", "form-a" ) "Expected kind"
+
+                        formB : Form.HtmlForm String String () msg
+                        formB =
+                            Form.form
+                                (\email ->
+                                    { combine =
+                                        Validation.succeed identity
+                                            |> Validation.andMap email
+                                    , view = \_ -> []
+                                    }
+                                )
+                                |> Form.field "email"
+                                    (Field.text
+                                        |> Field.required "Required"
+                                        |> Field.formatOnEvent noOpFormatter
+                                    )
+                                |> Form.hiddenKind ( "kind", "form-b" ) "Expected kind"
+
+                        handler =
+                            Form.Handler.init identity formA
+                                |> Form.Handler.with identity formB
+                    in
+                    Form.Handler.run
+                        (fields
+                            [ ( "kind", "form-b" )
+                            , ( "email", "test@example.com" )
+                            ]
+                        )
+                        handler
+                        |> Expect.equal (Valid "test@example.com")
             ]
         ]
 


### PR DESCRIPTION
Continues from the discussion in #23 and builds on the [`field-event-hooks`](https://github.com/dillonkearns/elm-form/tree/field-event-hooks) branch.

## The problem

There's no way to transform a field's value when the user interacts with it. If you need to format a phone number as someone types, or clean up whitespace when they tab away, you have to work outside of `elm-form` by intercepting form state, mutating it, and feeding it back in.

## What this does

This is your `formatOnEvent` API from `field-event-hooks`. The main difference is that event handlers live in the `Validation` type instead of on `Form`, so they flow through `andMap`/`andThen` and work with `Form.dynamic` too.

## Examples

**Expiration date, format as the user types (`1225` becomes `12 / 25`):**

```elm
import Form.Field as Field exposing (EventInfo(..))
import Form.Field.Selection as Selection

Field.text
    |> Field.formatOnEvent
        (\event ->
            case event of
                Input selection ->
                    if Selection.cursorAtEnd selection then
                        Just (formatExpDate (Selection.value selection))
                    else
                        Nothing

                _ ->
                    Nothing
        )

formatExpDate : String -> String
formatExpDate raw =
    let
        digits =
            String.filter Char.isDigit raw
                |> String.left 4
    in
    if String.length digits > 2 then
        String.left 2 digits ++ " / " ++ String.dropLeft 2 digits
    else
        digits
```

The `Selection.cursorAtEnd` check matters here. Reformatting a value moves the cursor to the end, so if the user clicks back to fix a typo, you want to leave the value alone until they're typing at the end again. This was the insight from Pete Murphy's real-world masking code in the discussion.

**Trim whitespace on blur:**

```elm
Field.text
    |> Field.formatOnEvent
        (\event ->
            case event of
                Blur value ->
                    Just (String.trim value)

                _ ->
                    Nothing
        )
```

## Why `Selection` exists

When you format on `Blur`, you just get a `String`. The user is done editing, safe to reformat. But when you format on `Input`, you're changing the value while they type. If you always reformat, you break the cursor position when they're editing the middle of the field.

`Selection` gives you the cursor position so you can make that call. `cursorAtEnd` handles the majority of cases. `zipper` is there if you need to know what's on either side of the cursor.
