### PR TITLE
Fix silent event drop when a form has a field named id

### DIFF
--- a/src/Form.elm
+++ b/src/Form.elm
@@ -1167,7 +1167,7 @@ renderHelper formState options_ attrs ((Internal.Form.Form _ _ _) as form_) =
                , Attr.novalidate True
                ]
             ++ ([ options_.action |> Maybe.map Attr.action ] |> List.filterMap identity)
-            ++ [ Internal.FieldEvent.formDataOnSubmit
+            ++ [ Internal.FieldEvent.formDataOnSubmit options_.id
                     |> Attr.map
                         (\formDataThing ->
                             let
@@ -1245,7 +1245,7 @@ renderStyledHelper formState options_ attrs ((Internal.Form.Form _ _ _) as form_
                , StyledAttr.novalidate True
                ]
             ++ ([ options_.action |> Maybe.map StyledAttr.action ] |> List.filterMap identity)
-            ++ [ Internal.FieldEvent.formDataOnSubmit
+            ++ [ Internal.FieldEvent.formDataOnSubmit options_.id
                     |> Attr.map
                         (\formDataThing ->
                             let

--- a/src/Internal/FieldEvent.elm
+++ b/src/Internal/FieldEvent.elm
@@ -42,17 +42,18 @@ type Method
 formDataOnSubmit : String -> Html.Attribute FormData
 formDataOnSubmit formId =
     Html.Events.preventDefaultOn "submit"
-        (Decode.map3
-            (\fields method action ->
+        (Decode.map4
+            (\fields method action id ->
                 { fields = fields
                 , method = method
                 , action = action
-                , id = Just formId
+                , id = id
                 }
             )
             fieldsDecoder
             (currentForm "method" methodDecoder)
             (currentForm "action" Decode.string)
+            (Decode.succeed (Just formId))
             |> Decode.map alwaysPreventDefault
         )
 

--- a/src/Internal/FieldEvent.elm
+++ b/src/Internal/FieldEvent.elm
@@ -53,7 +53,7 @@ formDataOnSubmit =
             fieldsDecoder
             (currentForm "method" methodDecoder)
             (currentForm "action" Decode.string)
-            (currentForm "id" (Decode.nullable Decode.string))
+            formIdDecoder
             |> Decode.map alwaysPreventDefault
         )
 
@@ -84,6 +84,16 @@ currentForm field_ decoder_ =
         [ Decode.at [ "submitter", "form" ] decoder_
         , Decode.at [ "currentTarget", field_ ] decoder_
         ]
+
+
+formIdDecoder : Decoder (Maybe String)
+formIdDecoder =
+    Decode.maybe
+        (Decode.oneOf
+            [ Decode.at [ "submitter", "form", "dataset", "elmFormId" ] Decode.string
+            , Decode.at [ "currentTarget", "dataset", "elmFormId" ] Decode.string
+            ]
+        )
 
 
 methodDecoder : Decoder Method

--- a/src/Internal/FieldEvent.elm
+++ b/src/Internal/FieldEvent.elm
@@ -39,21 +39,20 @@ type Method
     | Post
 
 
-formDataOnSubmit : Html.Attribute FormData
-formDataOnSubmit =
+formDataOnSubmit : String -> Html.Attribute FormData
+formDataOnSubmit formId =
     Html.Events.preventDefaultOn "submit"
-        (Decode.map4
-            (\fields method action id ->
+        (Decode.map3
+            (\fields method action ->
                 { fields = fields
                 , method = method
                 , action = action
-                , id = id
+                , id = Just formId
                 }
             )
             fieldsDecoder
             (currentForm "method" methodDecoder)
             (currentForm "action" Decode.string)
-            formIdDecoder
             |> Decode.map alwaysPreventDefault
         )
 
@@ -84,16 +83,6 @@ currentForm field_ decoder_ =
         [ Decode.at [ "submitter", "form" ] decoder_
         , Decode.at [ "currentTarget", field_ ] decoder_
         ]
-
-
-formIdDecoder : Decoder (Maybe String)
-formIdDecoder =
-    Decode.maybe
-        (Decode.oneOf
-            [ Decode.at [ "submitter", "form", "dataset", "elmFormId" ] Decode.string
-            , Decode.at [ "currentTarget", "dataset", "elmFormId" ] Decode.string
-            ]
-        )
 
 
 methodDecoder : Decoder Method

--- a/src/Pages/FormState.elm
+++ b/src/Pages/FormState.elm
@@ -15,6 +15,7 @@ listeners formId =
     , Html.Events.on "focusout" fieldEventDecoder
     , Html.Events.on "input" fieldEventDecoder
     , Attr.id formId
+    , Attr.attribute "data-elm-form-id" formId
     ]
 
 
@@ -23,7 +24,7 @@ fieldEventDecoder : Decoder FieldEvent
 fieldEventDecoder =
     Decode.map4 FieldEvent
         inputValueDecoder
-        (Decode.at [ "currentTarget", "id" ] Decode.string)
+        (Decode.at [ "currentTarget", "dataset", "elmFormId" ] Decode.string)
         (Decode.at [ "target", "name" ] Decode.string
             |> Decode.andThen
                 (\name ->

--- a/src/Pages/FormState.elm
+++ b/src/Pages/FormState.elm
@@ -11,20 +11,19 @@ import Json.Decode as Decode exposing (Decoder)
 {-| -}
 listeners : String -> List (Attribute FieldEvent)
 listeners formId =
-    [ Html.Events.on "focusin" fieldEventDecoder
-    , Html.Events.on "focusout" fieldEventDecoder
-    , Html.Events.on "input" fieldEventDecoder
+    [ Html.Events.on "focusin" (fieldEventDecoder formId)
+    , Html.Events.on "focusout" (fieldEventDecoder formId)
+    , Html.Events.on "input" (fieldEventDecoder formId)
     , Attr.id formId
-    , Attr.attribute "data-elm-form-id" formId
     ]
 
 
 {-| -}
-fieldEventDecoder : Decoder FieldEvent
-fieldEventDecoder =
+fieldEventDecoder : String -> Decoder FieldEvent
+fieldEventDecoder formId =
     Decode.map4 FieldEvent
         inputValueDecoder
-        (Decode.at [ "currentTarget", "dataset", "elmFormId" ] Decode.string)
+        (Decode.succeed formId)
         (Decode.at [ "target", "name" ] Decode.string
             |> Decode.andThen
                 (\name ->

--- a/tests/FormEventTests.elm
+++ b/tests/FormEventTests.elm
@@ -27,7 +27,7 @@ formWithHiddenField hiddenName =
             , view = \_ -> []
             }
         )
-        |> Form.hiddenField hiddenName (Field.text |> Field.required "Required")
+        |> Form.field hiddenName (Field.text |> Field.required "Required")
         |> Form.field "name" (Field.text |> Field.required "Required")
 
 
@@ -86,7 +86,7 @@ updatedNameValue result =
 
 all : Test
 all =
-    describe "a hidden field named \"id\" shadows form.id via [LegacyOverrideBuiltIns]"
+    describe "a field named \"id\" shadows form.id"
         [ test "control: input event on a form with a non-reserved hidden field name works" <|
             \() ->
                 renderForm "record-id"
@@ -95,7 +95,7 @@ all =
                     |> Event.toResult
                     |> updatedNameValue
                     |> Expect.equal (Just "hello")
-        , test "input event on a form with a hidden field named \"id\" still updates form state" <|
+        , test "input event on a form with a field named \"id\" still updates form state" <|
             \() ->
                 renderForm "id"
                     |> Query.fromHtml

--- a/tests/FormEventTests.elm
+++ b/tests/FormEventTests.elm
@@ -14,7 +14,6 @@ import Test.Html.Query as Query
 
 type Msg
     = FormMsg (Form.Msg Msg)
-    | Submitted
 
 
 formWithHiddenField : String -> Form.HtmlForm String ( String, String ) input Msg
@@ -32,8 +31,8 @@ formWithHiddenField hiddenName =
         |> Form.field "name" (Field.text |> Field.required "Required")
 
 
-renderInputForm : String -> Html.Html Msg
-renderInputForm hiddenName =
+renderForm : String -> Html.Html Msg
+renderForm hiddenName =
     formWithHiddenField hiddenName
         |> Form.renderHtml
             { submitting = False
@@ -42,34 +41,6 @@ renderInputForm hiddenName =
             }
             (Form.options "myForm")
             []
-
-
-renderSubmitForm : String -> Html.Html Msg
-renderSubmitForm hiddenName =
-    formWithHiddenField hiddenName
-        |> Form.renderHtml
-            { submitting = False
-            , state = Form.init
-            , toMsg = FormMsg
-            }
-            (Form.options "myForm"
-                |> Form.withAction "/submit"
-                |> Form.withOnSubmit (\_ -> Submitted)
-            )
-            []
-
-
-shadowedElement : String -> Encode.Value
-shadowedElement name =
-    Encode.object
-        [ ( "tagName", Encode.string "INPUT" )
-        , ( "name", Encode.string name )
-        ]
-
-
-dataset : Encode.Value
-dataset =
-    Encode.object [ ( "elmFormId", Encode.string "myForm" ) ]
 
 
 inputEvent : Encode.Value -> ( String, Encode.Value )
@@ -85,38 +56,18 @@ inputEvent idValue =
                 ]
           )
         , ( "currentTarget"
-          , Encode.object
-                [ ( "id", idValue )
-                , ( "dataset", dataset )
-                ]
+          , Encode.object [ ( "id", idValue ) ]
           )
         ]
     )
 
 
-submitEvent : Encode.Value -> ( String, Encode.Value )
-submitEvent idValue =
-    ( "submit"
-    , Encode.object
-        [ ( "type", Encode.string "submit" )
-        , ( "currentTarget"
-          , Encode.object
-                [ ( "id", idValue )
-                , ( "method", Encode.string "post" )
-                , ( "action", Encode.string "/submit" )
-                , ( "dataset", dataset )
-                ]
-          )
+shadowedIdElement : Encode.Value
+shadowedIdElement =
+    Encode.object
+        [ ( "tagName", Encode.string "INPUT" )
+        , ( "name", Encode.string "id" )
         ]
-    )
-
-
-fieldValue : String -> Form.Model -> Maybe String
-fieldValue fieldName model =
-    model
-        |> Dict.get "myForm"
-        |> Maybe.andThen (.fields >> Dict.get fieldName)
-        |> Maybe.map .value
 
 
 updatedNameValue : Result String Msg -> Maybe String
@@ -125,18 +76,9 @@ updatedNameValue result =
         Ok (FormMsg formMsg) ->
             Form.updateWithMsg formMsg Form.init
                 |> Tuple.first
-                |> fieldValue "name"
-
-        _ ->
-            Nothing
-
-
-dispatchedOnSubmit : Result String Msg -> Maybe Msg
-dispatchedOnSubmit result =
-    case result of
-        Ok (FormMsg formMsg) ->
-            Form.updateWithMsg formMsg Form.init
-                |> Tuple.second
+                |> Dict.get "myForm"
+                |> Maybe.andThen (.fields >> Dict.get "name")
+                |> Maybe.map .value
 
         _ ->
             Nothing
@@ -145,36 +87,20 @@ dispatchedOnSubmit result =
 all : Test
 all =
     describe "a hidden field named \"id\" shadows form.id via [LegacyOverrideBuiltIns]"
-        [ test "input event on a form with a non-reserved hidden field name works" <|
+        [ test "control: input event on a form with a non-reserved hidden field name works" <|
             \() ->
-                renderInputForm "record-id"
+                renderForm "record-id"
                     |> Query.fromHtml
                     |> Event.simulate (inputEvent (Encode.string "myForm"))
                     |> Event.toResult
                     |> updatedNameValue
                     |> Expect.equal (Just "hello")
-        , test "submit event on a form with a non-reserved hidden field name fires onSubmit" <|
-            \() ->
-                renderSubmitForm "record-id"
-                    |> Query.fromHtml
-                    |> Event.simulate (submitEvent (Encode.string "myForm"))
-                    |> Event.toResult
-                    |> dispatchedOnSubmit
-                    |> Expect.equal (Just Submitted)
         , test "input event on a form with a hidden field named \"id\" still updates form state" <|
             \() ->
-                renderInputForm "id"
+                renderForm "id"
                     |> Query.fromHtml
-                    |> Event.simulate (inputEvent (shadowedElement "id"))
+                    |> Event.simulate (inputEvent shadowedIdElement)
                     |> Event.toResult
                     |> updatedNameValue
                     |> Expect.equal (Just "hello")
-        , test "submit event on a form with a hidden field named \"id\" still fires onSubmit" <|
-            \() ->
-                renderSubmitForm "id"
-                    |> Query.fromHtml
-                    |> Event.simulate (submitEvent (shadowedElement "id"))
-                    |> Event.toResult
-                    |> dispatchedOnSubmit
-                    |> Expect.equal (Just Submitted)
         ]

--- a/tests/FormEventTests.elm
+++ b/tests/FormEventTests.elm
@@ -1,0 +1,180 @@
+module FormEventTests exposing (all)
+
+import Dict
+import Expect
+import Form
+import Form.Field as Field
+import Form.Validation as Validation
+import Html
+import Json.Encode as Encode
+import Test exposing (Test, describe, test)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+
+
+type Msg
+    = FormMsg (Form.Msg Msg)
+    | Submitted
+
+
+formWithHiddenField : String -> Form.HtmlForm String ( String, String ) input Msg
+formWithHiddenField hiddenName =
+    Form.form
+        (\hidden name ->
+            { combine =
+                Validation.succeed Tuple.pair
+                    |> Validation.andMap hidden
+                    |> Validation.andMap name
+            , view = \_ -> []
+            }
+        )
+        |> Form.hiddenField hiddenName (Field.text |> Field.required "Required")
+        |> Form.field "name" (Field.text |> Field.required "Required")
+
+
+renderInputForm : String -> Html.Html Msg
+renderInputForm hiddenName =
+    formWithHiddenField hiddenName
+        |> Form.renderHtml
+            { submitting = False
+            , state = Form.init
+            , toMsg = FormMsg
+            }
+            (Form.options "myForm")
+            []
+
+
+renderSubmitForm : String -> Html.Html Msg
+renderSubmitForm hiddenName =
+    formWithHiddenField hiddenName
+        |> Form.renderHtml
+            { submitting = False
+            , state = Form.init
+            , toMsg = FormMsg
+            }
+            (Form.options "myForm"
+                |> Form.withAction "/submit"
+                |> Form.withOnSubmit (\_ -> Submitted)
+            )
+            []
+
+
+shadowedElement : String -> Encode.Value
+shadowedElement name =
+    Encode.object
+        [ ( "tagName", Encode.string "INPUT" )
+        , ( "name", Encode.string name )
+        ]
+
+
+dataset : Encode.Value
+dataset =
+    Encode.object [ ( "elmFormId", Encode.string "myForm" ) ]
+
+
+inputEvent : Encode.Value -> ( String, Encode.Value )
+inputEvent idValue =
+    ( "input"
+    , Encode.object
+        [ ( "type", Encode.string "input" )
+        , ( "target"
+          , Encode.object
+                [ ( "type", Encode.string "text" )
+                , ( "value", Encode.string "hello" )
+                , ( "name", Encode.string "name" )
+                ]
+          )
+        , ( "currentTarget"
+          , Encode.object
+                [ ( "id", idValue )
+                , ( "dataset", dataset )
+                ]
+          )
+        ]
+    )
+
+
+submitEvent : Encode.Value -> ( String, Encode.Value )
+submitEvent idValue =
+    ( "submit"
+    , Encode.object
+        [ ( "type", Encode.string "submit" )
+        , ( "currentTarget"
+          , Encode.object
+                [ ( "id", idValue )
+                , ( "method", Encode.string "post" )
+                , ( "action", Encode.string "/submit" )
+                , ( "dataset", dataset )
+                ]
+          )
+        ]
+    )
+
+
+fieldValue : String -> Form.Model -> Maybe String
+fieldValue fieldName model =
+    model
+        |> Dict.get "myForm"
+        |> Maybe.andThen (.fields >> Dict.get fieldName)
+        |> Maybe.map .value
+
+
+updatedNameValue : Result String Msg -> Maybe String
+updatedNameValue result =
+    case result of
+        Ok (FormMsg formMsg) ->
+            Form.updateWithMsg formMsg Form.init
+                |> Tuple.first
+                |> fieldValue "name"
+
+        _ ->
+            Nothing
+
+
+dispatchedOnSubmit : Result String Msg -> Maybe Msg
+dispatchedOnSubmit result =
+    case result of
+        Ok (FormMsg formMsg) ->
+            Form.updateWithMsg formMsg Form.init
+                |> Tuple.second
+
+        _ ->
+            Nothing
+
+
+all : Test
+all =
+    describe "a hidden field named \"id\" shadows form.id via [LegacyOverrideBuiltIns]"
+        [ test "input event on a form with a non-reserved hidden field name works" <|
+            \() ->
+                renderInputForm "record-id"
+                    |> Query.fromHtml
+                    |> Event.simulate (inputEvent (Encode.string "myForm"))
+                    |> Event.toResult
+                    |> updatedNameValue
+                    |> Expect.equal (Just "hello")
+        , test "submit event on a form with a non-reserved hidden field name fires onSubmit" <|
+            \() ->
+                renderSubmitForm "record-id"
+                    |> Query.fromHtml
+                    |> Event.simulate (submitEvent (Encode.string "myForm"))
+                    |> Event.toResult
+                    |> dispatchedOnSubmit
+                    |> Expect.equal (Just Submitted)
+        , test "input event on a form with a hidden field named \"id\" still updates form state" <|
+            \() ->
+                renderInputForm "id"
+                    |> Query.fromHtml
+                    |> Event.simulate (inputEvent (shadowedElement "id"))
+                    |> Event.toResult
+                    |> updatedNameValue
+                    |> Expect.equal (Just "hello")
+        , test "submit event on a form with a hidden field named \"id\" still fires onSubmit" <|
+            \() ->
+                renderSubmitForm "id"
+                    |> Query.fromHtml
+                    |> Event.simulate (submitEvent (shadowedElement "id"))
+                    |> Event.toResult
+                    |> dispatchedOnSubmit
+                    |> Expect.equal (Just Submitted)
+        ]

--- a/tests/FormEventTests.elm
+++ b/tests/FormEventTests.elm
@@ -16,24 +16,24 @@ type Msg
     = FormMsg (Form.Msg Msg)
 
 
-formWithHiddenField : String -> Form.HtmlForm String ( String, String ) input Msg
-formWithHiddenField hiddenName =
+formWithField : String -> Form.HtmlForm String ( String, String ) input Msg
+formWithField name =
     Form.form
-        (\hidden name ->
+        (\id_ name_ ->
             { combine =
                 Validation.succeed Tuple.pair
-                    |> Validation.andMap hidden
-                    |> Validation.andMap name
+                    |> Validation.andMap id_
+                    |> Validation.andMap name_
             , view = \_ -> []
             }
         )
-        |> Form.field hiddenName (Field.text |> Field.required "Required")
+        |> Form.field name (Field.text |> Field.required "Required")
         |> Form.field "name" (Field.text |> Field.required "Required")
 
 
 renderForm : String -> Html.Html Msg
-renderForm hiddenName =
-    formWithHiddenField hiddenName
+renderForm name =
+    formWithField name
         |> Form.renderHtml
             { submitting = False
             , state = Form.init
@@ -87,7 +87,7 @@ updatedNameValue result =
 all : Test
 all =
     describe "a field named \"id\" shadows form.id"
-        [ test "control: input event on a form with a non-reserved hidden field name works" <|
+        [ test "control: input event on a form with a non-reserved field name works" <|
             \() ->
                 renderForm "record-id"
                     |> Query.fromHtml


### PR DESCRIPTION
## The problem

When a form contains `<input name="id">`, `form.id` returns that input element instead of the form's id string. Named form controls shadow properties inherited from the prototype chain (see [MDN: HTMLFormElement — Issues with naming elements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#issues_with_naming_elements)).

Event decoders in elm-form read `event.currentTarget.id` as a string, fail on the object they actually get, and since Elm swallows failed event decoders without logging, every focus/blur/input/submit event silently stops firing. No error, no feedback. The form just stops responding. Confirmed in an [Ellie](https://ellie-app.com/yvRnw4CFD56a1).

`id` as a field name is common (think edit-record forms), so this is easy to hit and painful to debug.

## The fix

The form id is already a `String` in Elm at render time (`Form.options : String -> Options ...` guarantees it), so there's no reason to round-trip it through a DOM attribute and read it back. Close over `formId` in the event decoders and use `Decode.succeed formId` instead. The DOM lookup that was vulnerable to shadowing is gone entirely.

## Tests

Added `tests/FormEventTests.elm` with control tests alongside the shadowing cases, so a regression in the decoder can't accidentally pass the shadowing tests for the wrong reason.